### PR TITLE
Skipping AzureKeyVaultClientHelper

### DIFF
--- a/sp_readmierrorlog/sp_readmierrorlog.sql
+++ b/sp_readmierrorlog/sp_readmierrorlog.sql
@@ -59,6 +59,7 @@ FilterText,
 FilterType
 )
 VALUES
+('`[AzureKeyVaultClientHelper::CheckDbAkvWrapUnwrap`]: Skipped',1),
 (' `[RotateDatabaseKeys`]',1),
 (' PVS',2),
 ('`[ERROR`] Log file %.xel cannot be deleted. Last error code from CreateFile is 32',2),


### PR DESCRIPTION
Ignoring log entries like:

[AzureKeyVaultClientHelper::CheckDbAkvWrapUnwrap]: Skipped as DB is not encrypted with AKV key.
[AzureKeyVaultClientHelper::CheckDbAkvWrapUnwrap]: Skipped as DEK does not exist.